### PR TITLE
README: fix typo and case

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ cd repo-name
 mkvirtualenv project_name
 
 # Install Django
-pip insall django
+pip install Django
 
 # Start project using template, in the repo's root
 # The --extension=ini parameter is important so that the pytest.ini file included is created correctly


### PR DESCRIPTION
It's `Django`, not `django`. https://pypi.python.org/pypi/Django